### PR TITLE
Add Role-Based Credentials Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fm-sbt-s3-resolver"
 
 organization := "com.frugalmechanic"
 
-version := "0.7.0-SNAPSHOT"
+version := "0.8.0-SNAPSHOT"
 
 description := "SBT S3 Resolver Plugin"
 
@@ -14,6 +14,7 @@ sbtPlugin := true
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % "1.10.16",
+  "com.amazonaws" % "aws-java-sdk-sts" % "1.10.16",
   "org.apache.ivy" % "ivy" % "2.3.0"
 )
 


### PR DESCRIPTION
-Role-Based chain has the highest precedence, but requires first the IAM
user credentials to be able to get the role credentials. So first the
regular provider chain is built and then supplied to the role-based
providers in their own chain. Finally they are joined together for the
final complete credential provider chain
-Bump minor release version to 0.8.0-SNAPSHOT
-Supports all the provider modes of the standard credentials: specify
the roleArn in systemProperty, env variable, or property files.
